### PR TITLE
Feature/http err

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,19 @@ func Handle(evt gotoearth.Event, ctx *runtime.Context) (interface{}, error) {
 ```
 
 How neat is that?
+
+### Errors ###
+
+When [downtoearth](https://github.com/cleardataeng/downtoearth) generates an API for API Gateway, the way that API detects and returns the correct error code, is by the text in the error message returned by the Lambda handler. `HTTPErr` is a helper to do just that. It is very easy to use.
+
+``` go
+	if len(cart.Items) == 0 {
+		return gotoearth.HTTPErr(404, errors.New("cart empty"))
+	}
+```
+
+In this contrived example, if you find a cart is empty, returning this would actually return an error with the message `[Not Found] cart empty`, which would trigger the API Gateway to respond with a 404 status.
+
+You can also pass in the constants defined in the net/http package that begin with "Status". For example, passing in http.StatusNotFound in the first argument would yield the same result as above.
+
+You can find the constants defined in the [net/http package](https://golang.org/pkg/net/http/#pkg-constants).

--- a/error.go
+++ b/error.go
@@ -1,0 +1,25 @@
+package gotoearth
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HTTPErr returns an error with the text updated as required by downtoearth.
+//
+// For example, passing in a 404 and an error with message "it isn't there"
+// yields a new error with message "[Not Found] it isn't there". This is how
+// downtoearth configures API Gateway to return the correct error.
+//
+// You can also pass in the constants defined in the net/http package that begin
+// with "Status". For example, passing in http.StatusNotFound in the first
+// argument would yield the same result as above.
+//
+// You can find the constants defined in the net/http package here:
+// https://golang.org/pkg/net/http/#pkg-constants
+func HTTPErr(code int, err error) error {
+	if txt := http.StatusText(code); txt != "" {
+		return fmt.Errorf("[%s] %s", txt, err)
+	}
+	return err
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,22 @@
+package gotoearth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+func ExampleHTTPErr() {
+	err := errors.New("oh noes")
+	fmt.Println(HTTPErr(400, err))
+	fmt.Println(HTTPErr(409, err))
+	fmt.Println(HTTPErr(500, err))
+	fmt.Println(HTTPErr(http.StatusNotFound, err))
+	fmt.Println(HTTPErr(http.StatusNotImplemented, err))
+	// Output:
+	// [Bad Request] oh noes
+	// [Conflict] oh noes
+	// [Internal Server Error] oh noes
+	// [Not Found] oh noes
+	// [Not Implemented] oh noes
+}


### PR DESCRIPTION
Added a simple helper to format HTTP errors for cleardataeng/downtoearth.

Actually, I expected to add several helpers, but this seemed much cleaner. Also, I figured since at least one other project is using the repository now, I probably should fork and flow.